### PR TITLE
'rexml', '~> 3.0'

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,16 +1,16 @@
 PATH
   remote: .
   specs:
-    swiss_bank_validator (1.0.1)
+    swiss_bank_validator (1.0.3)
       activemodel (>= 6.1.7.6)
-      rexml (~> 3.2.5)
+      rexml (~> 3.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.1.2)
-      activesupport (= 7.1.2)
-    activesupport (7.1.2)
+    activemodel (7.1.3.4)
+      activesupport (= 7.1.3.4)
+    activesupport (7.1.3.4)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -21,16 +21,15 @@ GEM
       mutex_m
       tzinfo (~> 2.0)
     ast (2.4.1)
-    base64 (0.1.1)
-    bigdecimal (3.1.5)
-    concurrent-ruby (1.2.2)
+    base64 (0.2.0)
+    bigdecimal (3.1.8)
+    concurrent-ruby (1.3.3)
     connection_pool (2.4.1)
     diff-lcs (1.4.4)
-    drb (2.2.0)
-      ruby2_keywords
-    i18n (1.14.1)
+    drb (2.2.1)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
-    minitest (5.20.0)
+    minitest (5.24.0)
     mutex_m (0.2.0)
     parallel (1.20.1)
     parser (2.7.2.0)
@@ -65,7 +64,6 @@ GEM
     rubocop-ast (1.3.0)
       parser (>= 2.7.1.5)
     ruby-progressbar (1.10.1)
-    ruby2_keywords (0.0.5)
     strscan (3.1.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)

--- a/lib/swiss_bank_validator/version.rb
+++ b/lib/swiss_bank_validator/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SwissBankValidator
-  VERSION = '1.0.2'
+  VERSION = '1.0.3'
 end

--- a/swiss_bank_validator.gemspec
+++ b/swiss_bank_validator.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'activemodel', '>= 6.1.7.6'
-  spec.add_dependency 'rexml', '~> 3.2.5'
+  spec.add_dependency 'rexml', '~> 3.0'
 
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '~> 1.5'


### PR DESCRIPTION
Actuellement, on définit:
`spec.add_dependency 'rexml', '~> 3.2.5'`

`~>` permet d'exprimer facilement que la dernière valeur peut évoluer.
'~> 3.2.5' = `>= 3.2.5 and < 3.3`.

Ici, ça nous empêche de monter à la version `3.3.2` pour fixer le CVE-2024-39908.

`~> 3.0` permet de faire `>= 3.0 and < 4.0`.

https://thoughtbot.com/blog/rubys-pessimistic-operator